### PR TITLE
feat(dev server): Initial dev server implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Pytest
+.xprocess/

--- a/COPYRIGHT-NOTICE
+++ b/COPYRIGHT-NOTICE
@@ -1,0 +1,31 @@
+Signficant portions of the updraft development server for falcon were adapted from the Werkzeug project. The Werkzeug project license and copyright notice are reproduced below, as per the terms of the license.
+
+Copyright (c) 2014 by the Werkzeug Team, see https://github.com/pallets/werkzeug/blob/master/AUTHORS for more details.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * The names of the contributors may not be used to endorse or
+      promote products derived from this software without specific
+      prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright (c) 2015 by the Falconry Team.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ setup(
     name='updraft',
     version='0.0.1',
     packages=find_packages(exclude=['tests']),
-    requires=['falcon'],
+    install_requires=['falcon'],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='updraft',
+    version='0.0.1',
+    packages=find_packages(exclude=['tests']),
+    requires=['falcon'],
+)

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,9 @@ setup(
     version='0.0.1',
     packages=find_packages(exclude=['tests']),
     install_requires=['falcon'],
+    entry_points={
+        'console_scripts': [
+            'updraft = updraft.__main__:main'
+        ]
+    }
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,151 @@
+"""
+    This module is adapted from Werkzeug's tests.conftest module.
+
+    :copyright: (c) 2014 by the Werkzeug Team, see COPYRIGHT-NOTICE for more
+    details.
+    :license: BSD, see COPYRIGHT-NOTICE for more details.
+"""
+
+import os
+import textwrap
+import time
+import signal
+import sys
+
+import pytest
+import requests
+
+from updraft.dev_server import run_dev_server
+from updraft.middleware import BasicMiddleware
+from updraft._compat import to_bytes
+
+
+@pytest.fixture
+def subprocess(xprocess):
+    # NOTE(csojinb): for reasons I don't understand, doing this seems to
+    # prevent some test-flakiness
+    return xprocess
+
+
+class PIDMiddleware(BasicMiddleware):
+
+    def __call__(self, environ, start_response):
+        if environ['PATH_INFO'] == '/_getpid':
+            start_response('200 OK', [('Content-Type', 'text/plain')])
+            return [to_bytes(str(os.getpid()))]
+        return self.app(environ, start_response)
+
+
+def _get_pid_middleware(app):
+    return PIDMiddleware(app)
+
+
+def _dev_server():
+    sys.path.insert(0, sys.argv[1])
+    import testsuite_app
+    app = _get_pid_middleware(testsuite_app.app)
+    run_dev_server(app, hostname='localhost', **testsuite_app.kwargs)
+
+if __name__ == '__main__':
+    _dev_server()
+
+
+@pytest.fixture
+def test_server(tmpdir, subprocess, request, monkeypatch):
+    """
+    Returns function that runs a dev server in a separate process for testing.
+
+    :param application: String with contents of module that will be created.
+    Module must have a global `app` object. It may optionally have a global
+    `kwargs` dict that specifies parameters to pass into the test server.
+    """
+
+    class TestServer(object):
+        subprocess_name = 'test_server'
+        last_pid = None
+
+        def __init__(self, application):
+            self.app_pkg = tmpdir.mkdir('testsuite_app')
+            self.appfile = self.app_pkg.join('__init__.py')
+            self._write_app_to_file(application)
+            self._build_server_info()
+
+            self.subprocess = subprocess
+
+        def overwrite_application(self, application):
+            self.appfile.remove()
+            self._write_app_to_file(application)
+            self.wait_for_reloader()
+
+        def request_pid(self):
+            for i in range(20):
+                time.sleep(0.1 * i)
+                try:
+                    self.last_pid = int(requests.get(self.url + '/_getpid',
+                                                     verify=False).text)
+                    return self.last_pid
+                except Exception:
+                    pass
+            return
+
+        def wait_for_reloader(self):
+            old_pid = self.last_pid
+            for i in range(20):
+                time.sleep(0.1 * i)
+                new_pid = self.request_pid()
+                if not new_pid:
+                    raise RuntimeError('Server is down.')
+                if self.request_pid() != old_pid:
+                    return
+            else:
+                raise RuntimeError('Server did not reload.')
+
+        def run(self, subprocess):
+            subprocess.ensure(
+                self.subprocess_name, self.preparefunc, restart=True)
+
+        def teardown(self):
+            # NOTE(csojinb): Comment below copied from Werkzeug. Not sure what
+            # exactly the problem is with xprocess, but removing this teardown
+            # does seem to cause some sort of state leakage between test runs.
+            #
+            # Killing the process group that runs the server, not just the
+            # parent process attached. xprocess is confused about Werkzeug's
+            # reloader and won't help here.
+            os.killpg(os.getpgid(self.last_pid), signal.SIGTERM)
+
+        def preparefunc(self, cwd):
+            # invokes _dev_server() by calling this file as main
+            args = [sys.executable, __file__, str(tmpdir)]
+            return self.request_pid, args
+
+        def _write_app_to_file(self, application):
+            self.appfile.write('\n\n'.join((
+                'import falcon',
+                'kwargs = dict(port=5001)',
+                'app = falcon.API()',
+                textwrap.dedent(application),
+                "app.add_route('/resource', Resource())"
+            )))
+
+        def _build_server_info(self):
+            testsuite_app = self._load_app_as_package()
+            self.port = testsuite_app.kwargs['port']
+            self.addr = 'localhost:{}'.format(self.port)
+            self.url = 'http://{}'.format(self.addr)
+
+        def _load_app_as_package(self):
+            monkeypatch.delitem(sys.modules, 'testsuite_app', raising=False)
+            monkeypatch.syspath_prepend(str(tmpdir))
+            import testsuite_app
+            return testsuite_app
+
+    def run_test_server(application):
+        server = TestServer(application)
+        server.run(subprocess)
+
+        request.addfinalizer(server.teardown)
+
+        return server
+
+    return run_test_server

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -1,0 +1,30 @@
+from argparse import Namespace
+
+import pytest
+
+from updraft.__main__ import get_parser
+
+
+@pytest.fixture(scope='module')
+def parser():
+    return get_parser()
+
+
+@pytest.mark.parametrize(('raw_args', 'expected'), [
+    (['mythings', 'app'], Namespace(
+        module='mythings', api='app', hostname='127.0.0.1', port=5000,
+        use_debugger=False, use_reloader=True)),
+    (['mythings', 'app', '--port', '7000', '--hostname', '10.1.2.1',
+      '--use-debugger', '--no-reload'],
+        Namespace(
+            module='mythings', api='app', hostname='10.1.2.1', port=7000,
+            use_debugger=True, use_reloader=False)),
+    (['mythings', 'app', '-p', '7000', '-H', '10.1.2.1', '-d',
+      '--no-reload'],
+        Namespace(
+            module='mythings', api='app', hostname='10.1.2.1', port=7000,
+            use_debugger=True, use_reloader=False)),
+])
+def test_argument_parser(raw_args, expected, parser):
+    args = parser.parse_args(raw_args)
+    assert args == expected

--- a/tests/test_dev_server.py
+++ b/tests/test_dev_server.py
@@ -5,8 +5,21 @@
 """
 
 import requests
-
 from flaky import flaky
+
+
+def test_broken_app_returns_500_response(test_server):
+    server = test_server(
+        """
+        class Resource(object):
+            def on_get(self, req, resp):
+                assert False
+        """
+    )
+
+    resp = requests.get('http://{}/resource'.format(server.addr))
+    assert resp.status_code == 500
+    assert 'Internal Server Error' in resp.text
 
 
 # TODO(csojinb): Figure out why this test flakes and fix it.

--- a/tests/test_dev_server.py
+++ b/tests/test_dev_server.py
@@ -1,0 +1,38 @@
+"""
+    This module and test_serving_werkzeug.py both test the functionality in
+    dev_server.py. The test_serving_werkzeug.py tests are adapted from
+    Werkzeug. The tests here are original updraft work.
+"""
+
+import requests
+
+from flaky import flaky
+
+
+# TODO(csojinb): Figure out why this test flakes and fix it.
+@flaky
+def test_application_reloads_when_code_changes(test_server):
+    app_string = """
+        class Resource(object):
+            def on_get(self, req, resp):
+                resp.status = falcon.HTTP_200
+                resp.body = '{}'
+
+        kwargs['use_reloader'] = True
+        kwargs['reloader_interval'] = 0.1
+    """
+    body1 = 'Hello, world!'
+    body2 = 'Goodbye, cruel world!'
+
+    server = test_server(app_string.format(body1))
+    url = 'http://{}/resource'.format(server.addr)
+    resp1 = requests.get(url)
+
+    assert resp1.status_code == 200
+    assert resp1.content == body1
+
+    server.overwrite_application(app_string.format(body2))
+    resp2 = requests.get(url)
+
+    assert resp2.status_code == 200
+    assert resp2.content == body2

--- a/tests/test_serving_werkzeug.py
+++ b/tests/test_serving_werkzeug.py
@@ -1,0 +1,45 @@
+"""
+    This module is adapted from Werkzeug's tests.serving module.
+
+    :copyright: (c) 2014 by Armin Ronacher.
+    :license: BSD, see COPYRIGHT-NOTICE for more details.
+"""
+
+import httplib
+
+import requests
+
+
+def test_server_actually_runs(test_server):
+    server = test_server(
+        """
+        class Resource(object):
+            def on_get(self, req, resp):
+                resp.status = falcon.HTTP_200
+                resp.body = 'Hello, world!'
+        """
+    )
+
+    resp = requests.get('http://{}/resource'.format(server.addr))
+    assert resp.content == 'Hello, world!'
+
+
+def test_absolute_url_request(test_server):
+    server = test_server(
+        """
+        class Resource(object):
+            def on_get(self, req, resp):
+                assert req.env['HTTP_HOST'] == 'notexisting.example.com:1337'
+                assert req.env['PATH_INFO'] == '/resource'
+                addr = req.env['HTTP_X_WERKZEUG_ADDR']
+                assert req.env['SERVER_PORT'] == addr.split(':')[1]
+                resp.status = falcon.HTTP_200
+                resp.body = 'YAY'
+        """
+    )
+
+    conn = httplib.HTTPConnection(server.addr)
+    conn.request('GET', 'http://notexisting.example.com:1337/resource#ignore',
+                 headers={'X-Werkzeug-Addr': server.addr})
+    resp = conn.getresponse()
+    assert resp.read() == 'YAY'

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""
+    This module is adapted from Werkzeug's tests.test_urls module.
+
+    :copyright: (c) 2014 by Armin Ronacher.
+    :license: BSD, see COPYRIGHT-NOTICE for more details.
+"""
+from updraft.urls import url_parse, url_unquote
+
+
+def strict_eq(x, y):
+    '''Equality test bypassing the implicit string conversion in Python 2'''
+    __tracebackhide__ = True
+    assert x == y
+    assert issubclass(type(x), type(y)) or issubclass(type(y), type(x))
+    if isinstance(x, dict) and isinstance(y, dict):
+        x = sorted(x.items())
+        y = sorted(y.items())
+    elif isinstance(x, set) and isinstance(y, set):
+        x = sorted(x)
+        y = sorted(y)
+    assert repr(x) == repr(y)
+
+
+def test_parsing():
+    url = url_parse('http://127.0.0.1:80/a/b/c?foo=bar#baz')
+    assert url.scheme == 'http'
+    assert url.netloc == '127.0.0.1:80'
+    assert url.path == '/a/b/c'
+    assert url.query == 'foo=bar'
+    assert url.fragment == 'baz'
+
+
+def test_quoting():
+    strict_eq(url_unquote('%C3%B6%C3%A4%C3%BC'), u'\xf6\xe4\xfc')

--- a/tools/test-requires
+++ b/tools/test-requires
@@ -1,0 +1,6 @@
+flaky
+pytest
+pytest-xprocess
+requests
+
+-e .

--- a/updraft/__init__.py
+++ b/updraft/__init__.py
@@ -1,1 +1,0 @@
-from dev_server import run_dev_server

--- a/updraft/__init__.py
+++ b/updraft/__init__.py
@@ -1,0 +1,1 @@
+from dev_server import run_dev_server

--- a/updraft/__main__.py
+++ b/updraft/__main__.py
@@ -1,0 +1,32 @@
+import argparse
+
+from dev_server import run_dev_server
+
+
+def main():
+    parser = get_parser()
+    kwargs = vars(parser.parse_args())
+
+    module_name = kwargs.pop('module')
+    api_name = kwargs.pop('api')
+
+    exec('from {} import {} as api'.format(module_name, api_name))
+    run_dev_server(api, **kwargs)
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('module')
+    parser.add_argument('api')
+    parser.add_argument('-H', '--hostname', default='127.0.0.1')
+    parser.add_argument('-p', '--port', default=5000, type=int)
+    parser.add_argument('-d', '--use-debugger',
+                        action='store_true', default=False)
+    parser.add_argument('--no-reload', action='store_false', default=True,
+                        dest='use_reloader')
+
+    return parser
+
+
+if __name__ == '__main__':
+    main()

--- a/updraft/_compat.py
+++ b/updraft/_compat.py
@@ -1,0 +1,211 @@
+# flake8: noqa
+# This whole file is full of lint errors
+"""
+    This module is adapted from the werkzeug._compat module.
+
+    :copyright: (c) 2014 by the Werkzeug Team, see COPYRIGHT-NOTICE for more
+    details.
+    :license: BSD, see COPYRIGHT-NOTICE for more details.
+"""
+import sys
+import operator
+import functools
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
+
+
+PY2 = sys.version_info[0] == 2
+
+_identity = lambda x: x
+
+if PY2:
+    unichr = unichr
+    text_type = unicode
+    string_types = (str, unicode)
+    integer_types = (int, long)
+    int_to_byte = chr
+
+    iterkeys = lambda d, *args, **kwargs: d.iterkeys(*args, **kwargs)
+    itervalues = lambda d, *args, **kwargs: d.itervalues(*args, **kwargs)
+    iteritems = lambda d, *args, **kwargs: d.iteritems(*args, **kwargs)
+
+    iterlists = lambda d, *args, **kwargs: d.iterlists(*args, **kwargs)
+    iterlistvalues = lambda d, *args, **kwargs: d.iterlistvalues(*args, **kwargs)
+
+    iter_bytes = lambda x: iter(x)
+
+    exec('def reraise(tp, value, tb=None):\n raise tp, value, tb')
+
+    def fix_tuple_repr(obj):
+        def __repr__(self):
+            cls = self.__class__
+            return '%s(%s)' % (cls.__name__, ', '.join(
+                '%s=%r' % (field, self[index])
+                for index, field in enumerate(cls._fields)
+            ))
+        obj.__repr__ = __repr__
+        return obj
+
+    def implements_iterator(cls):
+        cls.next = cls.__next__
+        del cls.__next__
+        return cls
+
+    def implements_to_string(cls):
+        cls.__unicode__ = cls.__str__
+        cls.__str__ = lambda x: x.__unicode__().encode('utf-8')
+        return cls
+
+    def native_string_result(func):
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs).encode('utf-8')
+        return functools.update_wrapper(wrapper, func)
+
+    def implements_bool(cls):
+        cls.__nonzero__ = cls.__bool__
+        del cls.__bool__
+        return cls
+
+    from itertools import imap, izip, ifilter
+    range_type = xrange
+
+    from StringIO import StringIO
+    from cStringIO import StringIO as BytesIO
+    NativeStringIO = BytesIO
+
+    def make_literal_wrapper(reference):
+        return lambda x: x
+
+    def normalize_string_tuple(tup):
+        """Normalizes a string tuple to a common type. Following Python 2
+        rules, upgrades to unicode are implicit.
+        """
+        if any(isinstance(x, text_type) for x in tup):
+            return tuple(to_unicode(x) for x in tup)
+        return tup
+
+    def try_coerce_native(s):
+        """Try to coerce a unicode string to native if possible. Otherwise,
+        leave it as unicode.
+        """
+        try:
+            return to_native(s)
+        except UnicodeError:
+            return s
+
+    wsgi_get_bytes = _identity
+
+    def wsgi_decoding_dance(s, charset='utf-8', errors='replace'):
+        return s.decode(charset, errors)
+
+    def wsgi_encoding_dance(s, charset='utf-8', errors='replace'):
+        if isinstance(s, bytes):
+            return s
+        return s.encode(charset, errors)
+
+    def to_bytes(x, charset=sys.getdefaultencoding(), errors='strict'):
+        if x is None:
+            return None
+        if isinstance(x, (bytes, bytearray, buffer)):
+            return bytes(x)
+        if isinstance(x, unicode):
+            return x.encode(charset, errors)
+        raise TypeError('Expected bytes')
+
+    def to_native(x, charset=sys.getdefaultencoding(), errors='strict'):
+        if x is None or isinstance(x, str):
+            return x
+        return x.encode(charset, errors)
+
+else:
+    unichr = chr
+    text_type = str
+    string_types = (str, )
+    integer_types = (int, )
+
+    iterkeys = lambda d, *args, **kwargs: iter(d.keys(*args, **kwargs))
+    itervalues = lambda d, *args, **kwargs: iter(d.values(*args, **kwargs))
+    iteritems = lambda d, *args, **kwargs: iter(d.items(*args, **kwargs))
+
+    iterlists = lambda d, *args, **kwargs: iter(d.lists(*args, **kwargs))
+    iterlistvalues = lambda d, *args, **kwargs: iter(d.listvalues(*args, **kwargs))
+
+    int_to_byte = operator.methodcaller('to_bytes', 1, 'big')
+
+    def iter_bytes(b):
+        return map(int_to_byte, b)
+
+    def reraise(tp, value, tb=None):
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+    fix_tuple_repr = _identity
+    implements_iterator = _identity
+    implements_to_string = _identity
+    implements_bool = _identity
+    native_string_result = _identity
+    imap = map
+    izip = zip
+    ifilter = filter
+    range_type = range
+
+    from io import StringIO, BytesIO
+    NativeStringIO = StringIO
+
+    def make_literal_wrapper(reference):
+        if isinstance(reference, text_type):
+            return lambda x: x
+        return lambda x: x.encode('latin1')
+
+    def normalize_string_tuple(tup):
+        """Ensures that all types in the tuple are either strings
+        or bytes.
+        """
+        tupiter = iter(tup)
+        is_text = isinstance(next(tupiter, None), text_type)
+        for arg in tupiter:
+            if isinstance(arg, text_type) != is_text:
+                raise TypeError('Cannot mix str and bytes arguments (got %s)'
+                                % repr(tup))
+        return tup
+
+    try_coerce_native = _identity
+
+    def wsgi_get_bytes(s):
+        return s.encode('latin1')
+
+    def wsgi_decoding_dance(s, charset='utf-8', errors='replace'):
+        return s.encode('latin1').decode(charset, errors)
+
+    def wsgi_encoding_dance(s, charset='utf-8', errors='replace'):
+        if isinstance(s, bytes):
+            return s.decode('latin1', errors)
+        return s.encode(charset).decode('latin1', errors)
+
+    def to_bytes(x, charset=sys.getdefaultencoding(), errors='strict'):
+        if x is None:
+            return None
+        if isinstance(x, (bytes, bytearray, memoryview)):  # noqa
+            return bytes(x)
+        if isinstance(x, str):
+            return x.encode(charset, errors)
+        raise TypeError('Expected bytes')
+
+    def to_native(x, charset=sys.getdefaultencoding(), errors='strict'):
+        if x is None or isinstance(x, str):
+            return x
+        return x.decode(charset, errors)
+
+
+def to_unicode(x, charset=sys.getdefaultencoding(), errors='strict',
+               allow_none_charset=False):
+    if x is None:
+        return None
+    if not isinstance(x, bytes):
+        return text_type(x)
+    if charset is None and allow_none_charset:
+        return x
+    return x.decode(charset, errors)

--- a/updraft/_internal.py
+++ b/updraft/_internal.py
@@ -1,0 +1,413 @@
+# -*- coding: utf-8 -*-
+"""
+    This module is adapted from the werkzeug._internal module. It provides
+    internally used helpers and constants.
+
+    :copyright: (c) 2014 by the Werkzeug Team, see COPYRIGHT-NOTICE for more
+    details.
+    :license: BSD, see COPYRIGHT-NOTICE for more details.
+"""
+import re
+import string
+import inspect
+from weakref import WeakKeyDictionary
+from datetime import datetime, date
+from itertools import chain
+
+from ._compat import iter_bytes, text_type, BytesIO, int_to_byte, \
+    range_type, integer_types
+
+
+_logger = None
+_empty_stream = BytesIO()
+_signature_cache = WeakKeyDictionary()
+_epoch_ord = date(1970, 1, 1).toordinal()
+_cookie_params = set((b'expires', b'path', b'comment',
+                      b'max-age', b'secure', b'httponly',
+                      b'version'))
+_legal_cookie_chars = (string.ascii_letters +
+                       string.digits +
+                       u"!#$%&'*+-.^_`|~:").encode('ascii')
+
+_cookie_quoting_map = {
+    b',': b'\\054',
+    b';': b'\\073',
+    b'"': b'\\"',
+    b'\\': b'\\\\',
+}
+for _i in chain(range_type(32), range_type(127, 256)):
+    _cookie_quoting_map[int_to_byte(_i)] = ('\\%03o' % _i).encode('latin1')
+
+
+_octal_re = re.compile(b'\\\\[0-3][0-7][0-7]')
+_quote_re = re.compile(b'[\\\\].')
+_legal_cookie_chars_re = b'[\w\d!#%&\'~_`><@,:/\$\*\+\-\.\^\|\)\(\?\}\{\=]'
+_cookie_re = re.compile(b"""(?x)
+    (?P<key>[^=]+)
+    \s*=\s*
+    (?P<val>
+        "(?:[^\\\\"]|\\\\.)*" |
+         (?:.*?)
+    )
+    \s*;
+""")
+
+
+class _Missing(object):
+
+    def __repr__(self):
+        return 'no value'
+
+    def __reduce__(self):
+        return '_missing'
+
+_missing = _Missing()
+
+
+def _get_environ(obj):
+    env = getattr(obj, 'environ', obj)
+    assert isinstance(env, dict), \
+        '%r is not a WSGI environment (has to be a dict)' % type(obj).__name__
+    return env
+
+
+def _log(type, message, *args, **kwargs):
+    """Log into the internal werkzeug logger."""
+    global _logger
+    if _logger is None:
+        import logging
+        _logger = logging.getLogger('werkzeug')
+        # Only set up a default log handler if the
+        # end-user application didn't set anything up.
+        if not logging.root.handlers and _logger.level == logging.NOTSET:
+            _logger.setLevel(logging.INFO)
+            handler = logging.StreamHandler()
+            _logger.addHandler(handler)
+    getattr(_logger, type)(message.rstrip(), *args, **kwargs)
+
+
+def _parse_signature(func):
+    """Return a signature object for the function."""
+    if hasattr(func, 'im_func'):
+        func = func.im_func
+
+    # if we have a cached validator for this function, return it
+    parse = _signature_cache.get(func)
+    if parse is not None:
+        return parse
+
+    # inspect the function signature and collect all the information
+    positional, vararg_var, kwarg_var, defaults = inspect.getargspec(func)
+    defaults = defaults or ()
+    arg_count = len(positional)
+    arguments = []
+    for idx, name in enumerate(positional):
+        if isinstance(name, list):
+            raise TypeError('cannot parse functions that unpack tuples '
+                            'in the function signature')
+        try:
+            default = defaults[idx - arg_count]
+        except IndexError:
+            param = (name, False, None)
+        else:
+            param = (name, True, default)
+        arguments.append(param)
+    arguments = tuple(arguments)
+
+    def parse(args, kwargs):
+        new_args = []
+        missing = []
+        extra = {}
+
+        # consume as many arguments as positional as possible
+        for idx, (name, has_default, default) in enumerate(arguments):
+            try:
+                new_args.append(args[idx])
+            except IndexError:
+                try:
+                    new_args.append(kwargs.pop(name))
+                except KeyError:
+                    if has_default:
+                        new_args.append(default)
+                    else:
+                        missing.append(name)
+            else:
+                if name in kwargs:
+                    extra[name] = kwargs.pop(name)
+
+        # handle extra arguments
+        extra_positional = args[arg_count:]
+        if vararg_var is not None:
+            new_args.extend(extra_positional)
+            extra_positional = ()
+        if kwargs and kwarg_var is None:
+            extra.update(kwargs)
+            kwargs = {}
+
+        return new_args, kwargs, missing, extra, extra_positional, \
+            arguments, vararg_var, kwarg_var
+    _signature_cache[func] = parse
+    return parse
+
+
+def _date_to_unix(arg):
+    """Converts a timetuple, integer or datetime object into the seconds from
+    epoch in utc.
+    """
+    if isinstance(arg, datetime):
+        arg = arg.utctimetuple()
+    elif isinstance(arg, integer_types + (float,)):
+        return int(arg)
+    year, month, day, hour, minute, second = arg[:6]
+    days = date(year, month, 1).toordinal() - _epoch_ord + day - 1
+    hours = days * 24 + hour
+    minutes = hours * 60 + minute
+    seconds = minutes * 60 + second
+    return seconds
+
+
+class _DictAccessorProperty(object):
+
+    """Baseclass for `environ_property` and `header_property`."""
+    read_only = False
+
+    def __init__(self, name, default=None, load_func=None, dump_func=None,
+                 read_only=None, doc=None):
+        self.name = name
+        self.default = default
+        self.load_func = load_func
+        self.dump_func = dump_func
+        if read_only is not None:
+            self.read_only = read_only
+        self.__doc__ = doc
+
+    def __get__(self, obj, type=None):
+        if obj is None:
+            return self
+        storage = self.lookup(obj)
+        if self.name not in storage:
+            return self.default
+        rv = storage[self.name]
+        if self.load_func is not None:
+            try:
+                rv = self.load_func(rv)
+            except (ValueError, TypeError):
+                rv = self.default
+        return rv
+
+    def __set__(self, obj, value):
+        if self.read_only:
+            raise AttributeError('read only property')
+        if self.dump_func is not None:
+            value = self.dump_func(value)
+        self.lookup(obj)[self.name] = value
+
+    def __delete__(self, obj):
+        if self.read_only:
+            raise AttributeError('read only property')
+        self.lookup(obj).pop(self.name, None)
+
+    def __repr__(self):
+        return '<%s %s>' % (
+            self.__class__.__name__,
+            self.name
+        )
+
+
+def _cookie_quote(b):
+    buf = bytearray()
+    all_legal = True
+    _lookup = _cookie_quoting_map.get
+    _push = buf.extend
+
+    for char in iter_bytes(b):
+        if char not in _legal_cookie_chars:
+            all_legal = False
+            char = _lookup(char, char)
+        _push(char)
+
+    if all_legal:
+        return bytes(buf)
+    return bytes(b'"' + buf + b'"')
+
+
+def _cookie_unquote(b):
+    if len(b) < 2:
+        return b
+    if b[:1] != b'"' or b[-1:] != b'"':
+        return b
+
+    b = b[1:-1]
+
+    i = 0
+    n = len(b)
+    rv = bytearray()
+    _push = rv.extend
+
+    while 0 <= i < n:
+        o_match = _octal_re.search(b, i)
+        q_match = _quote_re.search(b, i)
+        if not o_match and not q_match:
+            rv.extend(b[i:])
+            break
+        j = k = -1
+        if o_match:
+            j = o_match.start(0)
+        if q_match:
+            k = q_match.start(0)
+        if q_match and (not o_match or k < j):
+            _push(b[i:k])
+            _push(b[k + 1:k + 2])
+            i = k + 2
+        else:
+            _push(b[i:j])
+            rv.append(int(b[j + 1:j + 4], 8))
+            i = j + 4
+
+    return bytes(rv)
+
+
+def _cookie_parse_impl(b):
+    """Lowlevel cookie parsing facility that operates on bytes."""
+    i = 0
+    n = len(b)
+
+    while i < n:
+        match = _cookie_re.search(b + b';', i)
+        if not match:
+            break
+
+        key = match.group('key').strip()
+        value = match.group('val')
+        i = match.end(0)
+
+        # Ignore parameters.  We have no interest in them.
+        if key.lower() not in _cookie_params:
+            yield _cookie_unquote(key), _cookie_unquote(value)
+
+
+def _encode_idna(domain):
+    # If we're given bytes, make sure they fit into ASCII
+    if not isinstance(domain, text_type):
+        domain.decode('ascii')
+        return domain
+
+    # Otherwise check if it's already ascii, then return
+    try:
+        return domain.encode('ascii')
+    except UnicodeError:
+        pass
+
+    # Otherwise encode each part separately
+    parts = domain.split('.')
+    for idx, part in enumerate(parts):
+        parts[idx] = part.encode('idna')
+    return b'.'.join(parts)
+
+
+def _decode_idna(domain):
+    # If the input is a string try to encode it to ascii to
+    # do the idna decoding.  if that fails because of an
+    # unicode error, then we already have a decoded idna domain
+    if isinstance(domain, text_type):
+        try:
+            domain = domain.encode('ascii')
+        except UnicodeError:
+            return domain
+
+    # Decode each part separately.  If a part fails, try to
+    # decode it with ascii and silently ignore errors.  This makes
+    # most sense because the idna codec does not have error handling
+    parts = domain.split(b'.')
+    for idx, part in enumerate(parts):
+        try:
+            parts[idx] = part.decode('idna')
+        except UnicodeError:
+            parts[idx] = part.decode('ascii', 'ignore')
+
+    return '.'.join(parts)
+
+
+def _make_cookie_domain(domain):
+    if domain is None:
+        return None
+    domain = _encode_idna(domain)
+    if b':' in domain:
+        domain = domain.split(b':', 1)[0]
+    if b'.' in domain:
+        return domain
+    raise ValueError(
+        'Setting \'domain\' for a cookie on a server running locally (ex: '
+        'localhost) is not supported by complying browsers. You should '
+        'have something like: \'127.0.0.1 localhost dev.localhost\' on '
+        'your hosts file and then point your server to run on '
+        '\'dev.localhost\' and also set \'domain\' for \'dev.localhost\''
+    )
+
+
+def _easteregg(app=None):
+    """Like the name says.  But who knows how it works?"""
+    def bzzzzzzz(gyver):
+        import base64
+        import zlib
+        return zlib.decompress(base64.b64decode(gyver)).decode('ascii')
+    gyver = u'\n'.join([x + (77 - len(x)) * u' ' for x in bzzzzzzz(b'''
+eJyFlzuOJDkMRP06xRjymKgDJCDQStBYT8BCgK4gTwfQ2fcFs2a2FzvZk+hvlcRvRJD148efHt9m
+9Xz94dRY5hGt1nrYcXx7us9qlcP9HHNh28rz8dZj+q4rynVFFPdlY4zH873NKCexrDM6zxxRymzz
+4QIxzK4bth1PV7+uHn6WXZ5C4ka/+prFzx3zWLMHAVZb8RRUxtFXI5DTQ2n3Hi2sNI+HK43AOWSY
+jmEzE4naFp58PdzhPMdslLVWHTGUVpSxImw+pS/D+JhzLfdS1j7PzUMxij+mc2U0I9zcbZ/HcZxc
+q1QjvvcThMYFnp93agEx392ZdLJWXbi/Ca4Oivl4h/Y1ErEqP+lrg7Xa4qnUKu5UE9UUA4xeqLJ5
+jWlPKJvR2yhRI7xFPdzPuc6adXu6ovwXwRPXXnZHxlPtkSkqWHilsOrGrvcVWXgGP3daXomCj317
+8P2UOw/NnA0OOikZyFf3zZ76eN9QXNwYdD8f8/LdBRFg0BO3bB+Pe/+G8er8tDJv83XTkj7WeMBJ
+v/rnAfdO51d6sFglfi8U7zbnr0u9tyJHhFZNXYfH8Iafv2Oa+DT6l8u9UYlajV/hcEgk1x8E8L/r
+XJXl2SK+GJCxtnyhVKv6GFCEB1OO3f9YWAIEbwcRWv/6RPpsEzOkXURMN37J0PoCSYeBnJQd9Giu
+LxYQJNlYPSo/iTQwgaihbART7Fcyem2tTSCcwNCs85MOOpJtXhXDe0E7zgZJkcxWTar/zEjdIVCk
+iXy87FW6j5aGZhttDBoAZ3vnmlkx4q4mMmCdLtnHkBXFMCReqthSGkQ+MDXLLCpXwBs0t+sIhsDI
+tjBB8MwqYQpLygZ56rRHHpw+OAVyGgaGRHWy2QfXez+ZQQTTBkmRXdV/A9LwH6XGZpEAZU8rs4pE
+1R4FQ3Uwt8RKEtRc0/CrANUoes3EzM6WYcFyskGZ6UTHJWenBDS7h163Eo2bpzqxNE9aVgEM2CqI
+GAJe9Yra4P5qKmta27VjzYdR04Vc7KHeY4vs61C0nbywFmcSXYjzBHdiEjraS7PGG2jHHTpJUMxN
+Jlxr3pUuFvlBWLJGE3GcA1/1xxLcHmlO+LAXbhrXah1tD6Ze+uqFGdZa5FM+3eHcKNaEarutAQ0A
+QMAZHV+ve6LxAwWnXbbSXEG2DmCX5ijeLCKj5lhVFBrMm+ryOttCAeFpUdZyQLAQkA06RLs56rzG
+8MID55vqr/g64Qr/wqwlE0TVxgoiZhHrbY2h1iuuyUVg1nlkpDrQ7Vm1xIkI5XRKLedN9EjzVchu
+jQhXcVkjVdgP2O99QShpdvXWoSwkp5uMwyjt3jiWCqWGSiaaPAzohjPanXVLbM3x0dNskJsaCEyz
+DTKIs+7WKJD4ZcJGfMhLFBf6hlbnNkLEePF8Cx2o2kwmYF4+MzAxa6i+6xIQkswOqGO+3x9NaZX8
+MrZRaFZpLeVTYI9F/djY6DDVVs340nZGmwrDqTCiiqD5luj3OzwpmQCiQhdRYowUYEA3i1WWGwL4
+GCtSoO4XbIPFeKGU13XPkDf5IdimLpAvi2kVDVQbzOOa4KAXMFlpi/hV8F6IDe0Y2reg3PuNKT3i
+RYhZqtkQZqSB2Qm0SGtjAw7RDwaM1roESC8HWiPxkoOy0lLTRFG39kvbLZbU9gFKFRvixDZBJmpi
+Xyq3RE5lW00EJjaqwp/v3EByMSpVZYsEIJ4APaHmVtpGSieV5CALOtNUAzTBiw81GLgC0quyzf6c
+NlWknzJeCsJ5fup2R4d8CYGN77mu5vnO1UqbfElZ9E6cR6zbHjgsr9ly18fXjZoPeDjPuzlWbFwS
+pdvPkhntFvkc13qb9094LL5NrA3NIq3r9eNnop9DizWOqCEbyRBFJTHn6Tt3CG1o8a4HevYh0XiJ
+sR0AVVHuGuMOIfbuQ/OKBkGRC6NJ4u7sbPX8bG/n5sNIOQ6/Y/BX3IwRlTSabtZpYLB85lYtkkgm
+p1qXK3Du2mnr5INXmT/78KI12n11EFBkJHHp0wJyLe9MvPNUGYsf+170maayRoy2lURGHAIapSpQ
+krEDuNoJCHNlZYhKpvw4mspVWxqo415n8cD62N9+EfHrAvqQnINStetek7RY2Urv8nxsnGaZfRr/
+nhXbJ6m/yl1LzYqscDZA9QHLNbdaSTTr+kFg3bC0iYbX/eQy0Bv3h4B50/SGYzKAXkCeOLI3bcAt
+mj2Z/FM1vQWgDynsRwNvrWnJHlespkrp8+vO1jNaibm+PhqXPPv30YwDZ6jApe3wUjFQobghvW9p
+7f2zLkGNv8b191cD/3vs9Q833z8t''').splitlines()])
+
+    def easteregged(environ, start_response):
+        def injecting_start_response(status, headers, exc_info=None):
+            headers.append(('X-Powered-By', 'Werkzeug'))
+            return start_response(status, headers, exc_info)
+        if app is not None and environ.get('QUERY_STRING') != 'macgybarchakku':
+            return app(environ, injecting_start_response)
+        injecting_start_response('200 OK', [('Content-Type', 'text/html')])
+        return [(u'''
+<!DOCTYPE html>
+<html>
+<head>
+<title>About Werkzeug</title>
+<style type="text/css">
+  body { font: 15px Georgia, serif; text-align: center; }
+  a { color: #333; text-decoration: none; }
+  h1 { font-size: 30px; margin: 20px 0 10px 0; }
+  p { margin: 0 0 30px 0; }
+  pre { font: 11px 'Consolas', 'Monaco', monospace; line-height: 0.95; }
+</style>
+</head>
+<body>
+<h1><a href="http://werkzeug.pocoo.org/">Werkzeug</a></h1>
+<p>the Swiss Army knife of Python web development.</p>
+<pre>%s\n\n\n</pre>
+</body>
+</html>''' % gyver).encode('latin1')]
+    return easteregged

--- a/updraft/_reloader.py
+++ b/updraft/_reloader.py
@@ -1,0 +1,144 @@
+"""
+    This module is adapted from the werkzeug._reloader module.
+
+    :copyright: (c) 2014 by the Werkzeug Team, see COPYRIGHT-NOTICE for more
+    details.
+    :license: BSD, see COPYRIGHT-NOTICE for more details.
+"""
+
+import os
+import sys
+import time
+import subprocess
+import threading
+from itertools import chain
+
+from ._internal import _log
+from ._compat import PY2, iteritems, text_type
+
+
+def _iter_module_files():
+    """This iterates over all relevant Python files.  It goes through all
+    loaded files from modules, all files in folders of already loaded modules
+    as well as all files reachable through a package.
+    """
+    # The list call is necessary on Python 3 in case the module
+    # dictionary modifies during iteration.
+    for module in [m for m in sys.modules.values() if m is not None]:
+        filename = _module_file_or_containing_zip_archive(module)
+        if filename is not None:
+            yield _clean_compiled_pyfiles(filename)
+
+
+def _module_file_or_containing_zip_archive(module):
+    filename = getattr(module, '__file__', None)
+    if not (filename is None or os.path.isfile(filename)):
+        filename = _find_zip_archive_path(filename)
+
+    return filename
+
+
+def _find_zip_archive_path(filename):
+    while not os.path.isfile(filename):
+        old = filename
+        filename = os.path.dirname(filename)
+        if filename == old:
+            return None
+
+    return filename
+
+
+def _clean_compiled_pyfiles(filename):
+    root, ext = os.path.splitext(filename)
+    return filename[:-1] if ext in ('.pyc', '.pyo') else filename
+
+
+class ReloaderLoop(object):
+    name = 'stat'
+
+    # wrapping with `staticmethod` is required in
+    # case time.sleep has been replaced by a non-c function (e.g. by
+    # `eventlet.monkey_patch`) before we get here
+    _sleep = staticmethod(time.sleep)
+
+    def __init__(self, extra_files=None, interval=1):
+        self.extra_files = set(
+            os.path.abspath(x) for x in extra_files or ())
+        self.interval = interval
+
+    def run(self):
+        mtimes = {}
+        while True:
+            for filename in chain(_iter_module_files(), self.extra_files):
+                try:
+                    mtime = os.stat(filename).st_mtime
+                except OSError:
+                    continue
+
+                old_time = mtimes.get(filename)
+                if old_time is None:
+                    mtimes[filename] = mtime
+                    continue
+
+                elif mtime > old_time:
+                    self.trigger_reload(filename)
+
+            self._sleep(self.interval)
+
+    def restart_with_reloader(self):
+        """Spawn a new Python interpreter with the same arguments as this one,
+        but running the reloader thread.
+        """
+        while True:
+            _log('info', ' * Restarting with %s' % self.name)
+            args = [sys.executable] + sys.argv
+            new_environ = os.environ.copy()
+            new_environ['WERKZEUG_RUN_MAIN'] = 'true'
+
+            # a weird bug on windows. sometimes unicode strings end up in the
+            # environment and subprocess.call does not like this, encode them
+            # to latin1 and continue.
+            if os.name == 'nt' and PY2:
+                new_environ = self._encode_latin1(new_environ)
+
+            exit_code = subprocess.call(args, env=new_environ)
+            if exit_code != 3:
+                return exit_code
+
+    @staticmethod
+    def _encode_latin1(environ):
+        return dict(
+            (key, value.encode(
+                'iso-8859-1') if isinstance(value, text_type) else value)
+            for key, value in iteritems(environ))
+
+    def trigger_reload(self, filename):
+        self.log_reload(filename)
+        sys.exit(3)
+
+    def log_reload(self, filename):
+        filename = os.path.abspath(filename)
+        _log('info', ' * Detected change in %r, reloading' % filename)
+
+
+def run_with_reloader(main_func, extra_files=None, interval=1):
+    """Run the given function in an independent python interpreter."""
+    import signal
+    reloader = ReloaderLoop(extra_files, interval)
+    signal.signal(signal.SIGTERM, lambda *args: sys.exit(0))
+    try:
+        if is_running_from_reloader():
+            t = threading.Thread(target=main_func, args=())
+            t.setDaemon(True)
+            t.start()
+            reloader.run()
+        else:
+            sys.exit(reloader.restart_with_reloader())
+    except KeyboardInterrupt:
+        pass
+
+
+def is_running_from_reloader():
+    """Check if the application is running from within the reloader subprocess.
+    """
+    return os.environ.get('WERKZEUG_RUN_MAIN') == 'true'

--- a/updraft/dev_server.py
+++ b/updraft/dev_server.py
@@ -1,0 +1,26 @@
+"""
+Unlike serving.py, this file is not directly adapted from Werkzeug. For now, it
+functions purely as a passthrough. It is intended as the main entrypoint for
+updraft, which can clearly separate original work from Werkzeug-inspired.
+"""
+
+from .serving import run_simple
+
+
+def run_dev_server(api, hostname='127.0.0.1', port=5000, use_reloader=False,
+                   use_debugger=False, reloader_interval=1):
+    """Runs a development WSGI server for a falcon application
+
+    Args:
+        api: A falcon API object
+        hostname (str, optional): The host for the application. Defaults to
+            `'127.0.0.1'`
+        port (int, optional): The port for the server. Defaults to `5000`
+        use_reloader (bool, optional): Should the server automatically restart
+            when the application code changes? Defaults to `False`
+        use_debugger (bool, optional) [unimplemented]: Should the server drop
+            you into `pdb` on exception? Defaults to `False`
+
+    """
+    run_simple(hostname, port, api, use_reloader=use_reloader,
+               use_debugger=use_debugger, reloader_interval=reloader_interval)

--- a/updraft/dev_server.py
+++ b/updraft/dev_server.py
@@ -8,7 +8,7 @@ from .serving import run_simple
 
 
 def run_dev_server(api, hostname='127.0.0.1', port=5000, use_reloader=False,
-                   use_debugger=False, reloader_interval=1):
+                   reloader_interval=1, use_debugger=False, debug_method=None):
     """Runs a development WSGI server for a falcon application
 
     Args:
@@ -18,9 +18,19 @@ def run_dev_server(api, hostname='127.0.0.1', port=5000, use_reloader=False,
         port (int, optional): The port for the server. Defaults to `5000`
         use_reloader (bool, optional): Should the server automatically restart
             when the application code changes? Defaults to `False`
-        use_debugger (bool, optional) [unimplemented]: Should the server drop
-            you into `pdb` on exception? Defaults to `False`
+        reloader_interval (int, optional): Interval (s) at which reloader looks
+            for code changes. Defaults to `1`
+        use_debugger (bool, optional): Should the server drop you into `pdb` on
+            exception? Defaults to `False`
+        debug_method (func(), optional): Function that takes no arguments which
+            should be run when the application gets an uncaught exception. If
+            None (and use_debugger == True), defaults to pdb.post_mortem().
 
     """
+    if use_debugger and debug_method is None:
+        import pdb
+        debug_method = pdb.post_mortem
+
     run_simple(hostname, port, api, use_reloader=use_reloader,
-               use_debugger=use_debugger, reloader_interval=reloader_interval)
+               reloader_interval=reloader_interval, use_debugger=use_debugger,
+               debug_method=debug_method)

--- a/updraft/middleware.py
+++ b/updraft/middleware.py
@@ -1,5 +1,7 @@
 import pdb
 
+from falcon.errors import HTTPInternalServerError
+
 
 class BasicMiddleware(object):
 
@@ -11,3 +13,23 @@ class BasicMiddleware(object):
 
     def add_error_handler(self, exception, handler=None):
         return self.app.add_error_handler(exception, handler)
+
+
+class BlanketErrorHandlerMiddleware(BasicMiddleware):
+
+    """WSGI middleware that returns 500s with tracebacks for uncaught
+    application exceptions"""
+
+    def __init__(self, app):
+        app.add_error_handler(Exception, self.handle_uncaught_exceptions)
+        self.app = app
+
+    @staticmethod
+    def handle_uncaught_exceptions(ex, req, resp, params):
+        import traceback
+        tb = traceback.format_exc()
+
+        raise HTTPInternalServerError(
+            title='500 Internal Server Error',
+            description=tb)
+

--- a/updraft/middleware.py
+++ b/updraft/middleware.py
@@ -33,3 +33,17 @@ class BlanketErrorHandlerMiddleware(BasicMiddleware):
             title='500 Internal Server Error',
             description=tb)
 
+
+class PdbDebugMiddleware(BasicMiddleware):
+
+    """WSGI middleware that enables pdb post-mortems for a given application"""
+
+    def __init__(self, app, debug_method=pdb.post_mortem):
+        self.debug_method = debug_method
+        app.add_error_handler(Exception, self.debug)
+        self.app = app
+
+    def debug(self, ex, req, resp, params):
+        self.debug_method()
+        BlanketErrorHandlerMiddleware.handle_uncaught_exceptions(
+            ex, req, resp, params)

--- a/updraft/middleware.py
+++ b/updraft/middleware.py
@@ -1,0 +1,13 @@
+import pdb
+
+
+class BasicMiddleware(object):
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        return self.app(environ, start_response)
+
+    def add_error_handler(self, exception, handler=None):
+        return self.app.add_error_handler(exception, handler)

--- a/updraft/serving.py
+++ b/updraft/serving.py
@@ -1,0 +1,294 @@
+# -*- coding: utf-8 -*-
+"""
+    This module is adapted from the werkzeug.serving module, as are several of
+    its dependencies.
+
+    :copyright: (c) 2014 by the Werkzeug Team, see COPYRIGHT-NOTICE for more
+    details.
+    :license: BSD, see COPYRIGHT-NOTICE for more details.
+"""
+
+from __future__ import with_statement
+
+import os
+import socket
+import sys
+import signal
+
+
+try:
+    from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+except ImportError:
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+
+from ._internal import _log
+from ._compat import reraise, wsgi_encoding_dance
+from ._reloader import is_running_from_reloader
+from .urls import url_parse, url_unquote
+
+
+class WSGIRequestHandler(BaseHTTPRequestHandler, object):
+
+    """A request handler that implements WSGI dispatching."""
+
+    def make_environ(self):
+        request_url = url_parse(self.path)
+
+        def shutdown_server():
+            self.server.shutdown_signal = True
+
+        url_scheme = 'http'
+        path_info = url_unquote(request_url.path)
+
+        environ = {
+            'wsgi.version':         (1, 0),
+            'wsgi.url_scheme':      url_scheme,
+            'wsgi.input':           self.rfile,
+            'wsgi.errors':          sys.stderr,
+            'wsgi.multithread':     False,
+            'wsgi.multiprocess':    False,
+            'wsgi.run_once':        False,
+            'werkzeug.server.shutdown': shutdown_server,
+            'SERVER_SOFTWARE':      self.server_version,
+            'REQUEST_METHOD':       self.command,
+            'SCRIPT_NAME':          '',
+            'PATH_INFO':            wsgi_encoding_dance(path_info),
+            'QUERY_STRING':         wsgi_encoding_dance(request_url.query),
+            'CONTENT_TYPE':         self.headers.get('Content-Type', ''),
+            'CONTENT_LENGTH':       self.headers.get('Content-Length', ''),
+            'REMOTE_ADDR':          self.client_address[0],
+            'REMOTE_PORT':          self.client_address[1],
+            'SERVER_NAME':          self.server.server_address[0],
+            'SERVER_PORT':          str(self.server.server_address[1]),
+            'SERVER_PROTOCOL':      self.request_version
+        }
+
+        for key, value in self.headers.items():
+            key = 'HTTP_' + key.upper().replace('-', '_')
+            if key not in ('HTTP_CONTENT_TYPE', 'HTTP_CONTENT_LENGTH'):
+                environ[key] = value
+
+        if request_url.netloc:
+            environ['HTTP_HOST'] = request_url.netloc
+
+        return environ
+
+    def run_wsgi(self):
+        if self.headers.get('Expect', '').lower().strip() == '100-continue':
+            self.wfile.write(b'HTTP/1.1 100 Continue\r\n\r\n')
+
+        self.environ = environ = self.make_environ()
+        headers_set = []
+        headers_sent = []
+
+        def write(data):
+            assert headers_set, 'write() before start_response'
+            if not headers_sent:
+                status, response_headers = headers_sent[:] = headers_set
+                try:
+                    code, msg = status.split(None, 1)
+                except ValueError:
+                    code, msg = status, ""
+                self.send_response(int(code), msg)
+                header_keys = set()
+                for key, value in response_headers:
+                    self.send_header(key, value)
+                    key = key.lower()
+                    header_keys.add(key)
+                if 'content-length' not in header_keys:
+                    self.close_connection = True
+                    self.send_header('Connection', 'close')
+                if 'server' not in header_keys:
+                    self.send_header('Server', self.version_string())
+                if 'date' not in header_keys:
+                    self.send_header('Date', self.date_time_string())
+                self.end_headers()
+
+            assert isinstance(data, bytes), 'applications must write bytes'
+            self.wfile.write(data)
+            self.wfile.flush()
+
+        def start_response(status, response_headers, exc_info=None):
+            if exc_info:
+                try:
+                    if headers_sent:
+                        reraise(*exc_info)
+                finally:
+                    exc_info = None
+            elif headers_set:
+                raise AssertionError('Headers already set')
+            headers_set[:] = [status, response_headers]
+            return write
+
+        def execute(app):
+            application_iter = app(environ, start_response)
+            try:
+                for data in application_iter:
+                    write(data)
+                if not headers_sent:
+                    write(b'')
+            finally:
+                if hasattr(application_iter, 'close'):
+                    application_iter.close()
+                application_iter = None
+
+        execute(self.server.app)
+
+    def handle(self):
+        """Handles a request ignoring dropped connections."""
+        rv = None
+        try:
+            rv = BaseHTTPRequestHandler.handle(self)
+        except (socket.error, socket.timeout) as e:
+            self.connection_dropped(e)
+
+        if self.server.shutdown_signal:
+            self.initiate_shutdown()
+        return rv
+
+    def initiate_shutdown(self):
+        """A horrible, horrible way to kill the server for Python 2.6 and
+        later.  It's the best we can do.
+        """
+        # Windows does not provide SIGKILL, go with SIGTERM then.
+        sig = getattr(signal, 'SIGKILL', signal.SIGTERM)
+        # reloader active
+        if is_running_from_reloader():
+            os.kill(os.getpid(), sig)
+        # python 2.7
+        self.server._BaseServer__shutdown_request = True
+        # python 2.6
+        self.server._BaseServer__serving = False
+
+    def connection_dropped(self, error, environ=None):
+        """Called if the connection was closed by the client.  By default
+        nothing happens.
+        """
+
+    def handle_one_request(self):
+        """Handle a single HTTP request."""
+        self.raw_requestline = self.rfile.readline()
+        if not self.raw_requestline:
+            self.close_connection = 1
+        elif self.parse_request():
+            return self.run_wsgi()
+
+    def send_response(self, code, message=None):
+        """Send the response header and log the response code."""
+        self.log_request(code)
+        if message is None:
+            message = code in self.responses and self.responses[code][0] or ''
+        if self.request_version != 'HTTP/0.9':
+            hdr = "%s %d %s\r\n" % (self.protocol_version, code, message)
+            self.wfile.write(hdr.encode('ascii'))
+
+    def version_string(self):
+        return BaseHTTPRequestHandler.version_string(self).strip()
+
+    def address_string(self):
+        return self.environ['REMOTE_ADDR']
+
+    def log_request(self, code='-', size='-'):
+        self.log('info', '"%s" %s %s', self.requestline, code, size)
+
+    def log_error(self, *args):
+        self.log('error', *args)
+
+    def log_message(self, format, *args):
+        self.log('info', format, *args)
+
+    def log(self, type, message, *args):
+        _log(type, '%s - - [%s] %s\n' % (self.address_string(),
+                                         self.log_date_time_string(),
+                                         message % args))
+
+
+def select_ip_version(host, port):
+    """Returns AF_INET4 or AF_INET6 depending on where to connect to."""
+
+    # NOTE(csojinb): This is a holdover comment from Werkzeug that I've kept
+    # for reference purposes.
+    #
+    # disabled due to problems with current ipv6 implementations
+    # and various operating systems.  Probably this code also is
+    # not supposed to work, but I can't come up with any other
+    # ways to implement this.
+    # try:
+    #     info = socket.getaddrinfo(host, port, socket.AF_UNSPEC,
+    #                               socket.SOCK_STREAM, 0,
+    #                               socket.AI_PASSIVE)
+    #     if info:
+    #         return info[0][0]
+    # except socket.gaierror:
+    #     pass
+    if ':' in host and hasattr(socket, 'AF_INET6'):
+        return socket.AF_INET6
+    return socket.AF_INET
+
+
+class BaseWSGIServer(HTTPServer, object):
+    """Simple single-threaded, single-process WSGI server."""
+    request_queue_size = 128
+
+    def __init__(self, host, port, app):
+        self.address_family = select_ip_version(host, port)
+        HTTPServer.__init__(self, (host, int(port)), WSGIRequestHandler)
+        self.app = app
+        self.shutdown_signal = False
+
+    def log(self, type, message, *args):
+        _log(type, message, *args)
+
+    def serve_forever(self):
+        self.shutdown_signal = False
+        try:
+            HTTPServer.serve_forever(self)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.server_close()
+
+    def handle_error(self, request, client_address):
+        return HTTPServer.handle_error(self, request, client_address)
+
+    def get_request(self):
+        con, info = self.socket.accept()
+        return con, info
+
+
+def run_simple(hostname, port, application, use_reloader=False,
+               reloader_interval=1, **kwargs):
+    """Start a WSGI application. Optionally auto-reload on code change.
+
+    :param hostname: The host for the application.  eg: ``'localhost'``
+    :param port: The port for the server.  eg: ``8080``
+    :param application: the WSGI application to execute
+    :param use_reloader: should the server automatically restart the python
+                         process if modules were changed?
+    :param reloader_interval: the interval for the reloader in seconds.
+    """
+
+    def run_server():
+        BaseWSGIServer(hostname, port, application).serve_forever()
+
+    if not is_running_from_reloader():
+        display_hostname = hostname != '*' and hostname or 'localhost'
+        if ':' in display_hostname:
+            display_hostname = '[%s]' % display_hostname
+        quit_msg = '(Press CTRL+C to quit)'
+        _log('info', ' * Running on http://{}:{}/ {}'.format(
+            display_hostname, port, quit_msg))
+
+    if use_reloader:
+        # Create and destroy a socket so that any exceptions are raised before
+        # we spawn a separate Python interpreter and lose this ability.
+        address_family = select_ip_version(hostname, port)
+        test_socket = socket.socket(address_family, socket.SOCK_STREAM)
+        test_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        test_socket.bind((hostname, port))
+        test_socket.close()
+
+        from ._reloader import run_with_reloader
+        run_with_reloader(run_server, interval=reloader_interval)
+    else:
+        run_server()

--- a/updraft/serving.py
+++ b/updraft/serving.py
@@ -25,6 +25,7 @@ from ._internal import _log
 from ._compat import reraise, wsgi_encoding_dance
 from ._reloader import is_running_from_reloader
 from .urls import url_parse, url_unquote
+from .middleware import BlanketErrorHandlerMiddleware
 
 
 class WSGIRequestHandler(BaseHTTPRequestHandler, object):
@@ -267,6 +268,7 @@ def run_simple(hostname, port, application, use_reloader=False,
                          process if modules were changed?
     :param reloader_interval: the interval for the reloader in seconds.
     """
+    application = BlanketErrorHandlerMiddleware(application)
 
     def run_server():
         BaseWSGIServer(hostname, port, application).serve_forever()

--- a/updraft/urls.py
+++ b/updraft/urls.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+"""
+    This module is adapted from the werkzeug.serving module, as are several of
+    its dependencies.
+
+    ``updraft.urls`` used to provide several wrapper functions for Python 2
+    urlparse, whose main purpose were to work around the behavior of the Py2
+    stdlib and its lack of unicode support. While this was already a somewhat
+    inconvenient situation, it got even more complicated because Python 3's
+    ``urllib.parse`` actually does handle unicode properly. In other words,
+    this module would wrap two libraries with completely different behavior. So
+    now this module contains a 2-and-3-compatible backport of Python 3's
+    ``urllib.parse``, which is mostly API-compatible.
+
+    :copyright: (c) 2014 by the Werkzeug Team, see COPYRIGHT-NOTICE for more
+    details.
+    :license: BSD, see COPYRIGHT-NOTICE for more details.
+"""
+import os
+import re
+from collections import namedtuple
+
+from ._compat import (
+    text_type, to_native, make_literal_wrapper, fix_tuple_repr)
+
+
+# A regular expression for what a valid scheme looks like
+_scheme_re = re.compile(r'^[a-zA-Z0-9+-.]+$')
+
+# Characters that are safe in any part of an URL.
+_always_safe = (b'abcdefghijklmnopqrstuvwxyz'
+                b'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-+')
+
+_hexdigits = '0123456789ABCDEFabcdef'
+_hextobyte = dict(
+    ((a + b).encode(), int(a + b, 16))
+    for a in _hexdigits for b in _hexdigits
+)
+
+
+URLTuple = fix_tuple_repr(namedtuple(
+    'URLTuple', ['scheme', 'netloc', 'path', 'query', 'fragment']))
+
+
+def _unquote_to_bytes(string, unsafe=''):
+    if isinstance(string, text_type):
+        string = string.encode('utf-8')
+    if isinstance(unsafe, text_type):
+        unsafe = unsafe.encode('utf-8')
+    unsafe = frozenset(bytearray(unsafe))
+    bits = iter(string.split(b'%'))
+    result = bytearray(next(bits, b''))
+    for item in bits:
+        try:
+            char = _hextobyte[item[:2]]
+            if char in unsafe:
+                raise KeyError()
+            result.append(char)
+            result.extend(item[2:])
+        except KeyError:
+            result.extend(b'%')
+            result.extend(item)
+    return bytes(result)
+
+
+def url_parse(url, scheme=None, allow_fragments=True):
+    """Parses a URL from a string into a :class:`URL` tuple.  If the URL
+    is lacking a scheme it can be provided as second argument. Otherwise,
+    it is ignored.  Optionally fragments can be stripped from the URL
+    by setting `allow_fragments` to `False`.
+
+    The inverse of this function is :func:`url_unparse`.
+
+    :param url: the URL to parse.
+    :param scheme: the default schema to use if the URL is schemaless.
+    :param allow_fragments: if set to `False` a fragment will be removed
+                            from the URL.
+    """
+    s = make_literal_wrapper(url)
+    # is_text_based = isinstance(url, text_type)
+
+    if scheme is None:
+        scheme = s('')
+    netloc = query = fragment = s('')
+    i = url.find(s(':'))
+    if i > 0 and _scheme_re.match(to_native(url[:i], errors='replace')):
+        # make sure "iri" is not actually a port number (in which case
+        # "scheme" is really part of the path)
+        rest = url[i + 1:]
+        if not rest or any(c not in s('0123456789') for c in rest):
+            # not a port number
+            scheme, url = url[:i].lower(), rest
+
+    if url[:2] == s('//'):
+        delim = len(url)
+        for c in s('/?#'):
+            wdelim = url.find(c, 2)
+            if wdelim >= 0:
+                delim = min(delim, wdelim)
+        netloc, url = url[2:delim], url[delim:]
+        if (s('[') in netloc and s(']') not in netloc) or \
+           (s(']') in netloc and s('[') not in netloc):
+            raise ValueError('Invalid IPv6 URL')
+
+    if allow_fragments and s('#') in url:
+        url, fragment = url.split(s('#'), 1)
+    if s('?') in url:
+        url, query = url.split(s('?'), 1)
+
+    return URLTuple(scheme, netloc, url, query, fragment)
+
+
+def url_unquote(string, charset='utf-8', errors='replace', unsafe=''):
+    """URL decode a single string with a given encoding.  If the charset
+    is set to `None` no unicode decoding is performed and raw bytes
+    are returned.
+
+    :param s: the string to unquote.
+    :param charset: the charset of the query string.  If set to `None`
+                    no unicode decoding will take place.
+    :param errors: the error handling for the charset decoding.
+    """
+    rv = _unquote_to_bytes(string, unsafe)
+    if charset is not None:
+        rv = rv.decode(charset, errors)
+    return rv


### PR DESCRIPTION
I have moved my dev server implementation over from https://github.com/falconry/falcon/pull/517. The initial status is basically the exact same implementation I put up for review over there. This is not intended to be mergeable yet, so feedback on design is most welcome. :smile:

The current functionality includes:
- auto-reloading
- legible tracebacks on exception (replacing werkzeug's fancy in-browser debugger, since that's less relevant for an API)
- option to drop into pdb debugger on exception

~~The current usage is Flask-like:~~
Modified to support command-line invocation:

```
# mything.py
import falcon

api = falcon.API()
```

```
$ updraft mything api
```

But, I like @kgriffs's (suggestion)[https://github.com/falconry/falcon/pull/517#issuecomment-114897903] to make it a command-line util, rather than having to make a py-file (`start.py` in the example above) to run at the command-line.

Ordinarily, I would not advocate for stuffing a first implementation with a whole bunch of features, but since we're starting from werkzeug, we could probably pick up some others without too much fuss. Other features I'm considering pulling in at the moment: 
- `extra_files`: files to watch outside of the application, e.g. config files, for triggering reloading
- threading: handling each request in a separate thread
- multiple processes

TODO:
- [x] add tests
- [x] handle licensing stuff for cannibalized werkzeug code
- [x] figure out which features of werkzeug's simple server we want to keep, other than the reloader, if any
- [x] strip down `serving.py` to only include what we need
- [x] ~~use `ipdb` if available~~ this might be difficult... the interfaces don't seem to be exactly the same
- [x] modify usage so that the server can be run from the command-line
- [ ] add `extra_files` support
- [ ] add basic usage docs
